### PR TITLE
Fix HLS path and output directory for watch page

### DIFF
--- a/webrtc-hls-demo/app/app/watch/page.tsx
+++ b/webrtc-hls-demo/app/app/watch/page.tsx
@@ -13,9 +13,9 @@ export default function WatchPage() {
     currentTime: 0,
     latency: 0
   });
-  
+
   const roomId = 'demo'; // You can make this dynamic
-  const hlsUrl = `http://localhost:3001/server/public/hls/${roomId}/stream.m3u8`;
+  const hlsUrl = `http://localhost:3001/hls/${roomId}/stream.m3u8`;
 
   useEffect(() => {
     if (!videoRef.current) return;

--- a/webrtc-hls-demo/server/src/ffmpeg/startHlsTranscoder.ts
+++ b/webrtc-hls-demo/server/src/ffmpeg/startHlsTranscoder.ts
@@ -12,8 +12,7 @@ export class HlsTranscoder {
 
   constructor(
     private roomId: string,
-    baseDir = '/mnt/c/Users/aniru/OneDrive/Desktop/Fermion/webrtc-hls-demo/public/hls'
-
+    baseDir = path.join(process.cwd(), 'public', 'hls')
   ) {
     this.outputDir = path.join(baseDir, roomId);
     


### PR DESCRIPTION
## Summary
- Correct watch page to use the server's `/hls/{roomId}/stream.m3u8` URL
- Generate HLS output inside the server's `public/hls` directory so files are served correctly

## Testing
- `pnpm --filter server build` *(fails: Could not find type declarations and TS errors)*
- `pnpm --filter app build` *(fails: Property 'videoTrack' does not exist on type 'RemoteStream | { peerId: any; }')*

------
https://chatgpt.com/codex/tasks/task_e_689ad86d41e88320a08094ec3c97664d